### PR TITLE
Add front desk features

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,39 @@
-# front-desk-allo-health-hg
+# Front Desk System
 
-# Harsha Vardhan G 
+This repository contains a minimal skeleton for a clinic front desk system. It uses a NestJS backend with SQLite and a Next.js frontend styled with Tailwind CSS.
+
+## Folder Structure
+
+- **backend** – NestJS application with entities and simple controllers for doctors, appointments and queue management.
+- **frontend** – Next.js project containing pages for queue management and appointments.
+
+## Running Locally
+
+Dependencies are not included due to environment restrictions. Install packages and run the servers locally:
+
+```bash
+# install backend deps
+npm install @nestjs/core @nestjs/common @nestjs/platform-express @nestjs/typeorm typeorm reflect-metadata sqlite3 rxjs @nestjs/config
+
+# start backend
+npx ts-node backend/src/main.ts
+
+# install frontend deps
+cd frontend
+npm install next react react-dom node-fetch tailwindcss
+npm run dev
+```
+
+The backend listens on `http://localhost:3001` and the Next.js frontend on `http://localhost:3000`.
+
+### Seeding Data
+
+Run the included seed script to populate the SQLite database with sample doctors, patients and an appointment:
+
+```bash
+npx ts-node backend/src/seed.ts
+```
+
+### Deployment
+
+The project is ready to deploy to services like Azure App Service. Build the frontend and start the backend as part of your startup command. Ensure the `clinic.db` SQLite file is persisted.

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -1,0 +1,25 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Doctor } from './entities/doctor.entity';
+import { Patient } from './entities/patient.entity';
+import { Appointment } from './entities/appointment.entity';
+import { DoctorModule } from './doctor/doctor.module';
+import { AppointmentModule } from './appointment/appointment.module';
+import { QueueModule } from './queue/queue.module';
+import { PatientModule } from './patient/patient.module';
+
+@Module({
+  imports: [
+    TypeOrmModule.forRoot({
+      type: 'sqlite',
+      database: 'clinic.db',
+      entities: [Doctor, Patient, Appointment],
+      synchronize: true,
+    }),
+    DoctorModule,
+    AppointmentModule,
+    QueueModule,
+    PatientModule,
+  ],
+})
+export class AppModule {}

--- a/backend/src/appointment/appointment.controller.ts
+++ b/backend/src/appointment/appointment.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { AppointmentService } from './appointment.service';
+
+@Controller('appointments')
+export class AppointmentController {
+  constructor(private service: AppointmentService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Post()
+  book(@Body() body: { patientId: number; doctorId: number; time: string }) {
+    const { patientId, doctorId, time } = body;
+    return this.service.book(patientId, doctorId, time);
+  }
+}

--- a/backend/src/appointment/appointment.module.ts
+++ b/backend/src/appointment/appointment.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Appointment } from '../entities/appointment.entity';
+import { AppointmentService } from './appointment.service';
+import { AppointmentController } from './appointment.controller';
+import { Doctor } from '../entities/doctor.entity';
+import { Patient } from '../entities/patient.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Appointment, Doctor, Patient])],
+  controllers: [AppointmentController],
+  providers: [AppointmentService],
+})
+export class AppointmentModule {}

--- a/backend/src/appointment/appointment.service.ts
+++ b/backend/src/appointment/appointment.service.ts
@@ -1,0 +1,26 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Appointment } from '../entities/appointment.entity';
+import { Doctor } from '../entities/doctor.entity';
+import { Patient } from '../entities/patient.entity';
+
+@Injectable()
+export class AppointmentService {
+  constructor(
+    @InjectRepository(Appointment) private repo: Repository<Appointment>,
+    @InjectRepository(Doctor) private doctorRepo: Repository<Doctor>,
+    @InjectRepository(Patient) private patientRepo: Repository<Patient>,
+  ) {}
+
+  async book(patientId: number, doctorId: number, time: string) {
+    const patient = await this.patientRepo.findOne({ where: { id: patientId } });
+    const doctor = await this.doctorRepo.findOne({ where: { id: doctorId } });
+    const appt = this.repo.create({ patient, doctor, time });
+    return this.repo.save(appt);
+  }
+
+  findAll() {
+    return this.repo.find({ relations: ['patient', 'doctor'] });
+  }
+}

--- a/backend/src/doctor/doctor.controller.ts
+++ b/backend/src/doctor/doctor.controller.ts
@@ -1,0 +1,17 @@
+import { Controller, Get, Post, Body } from '@nestjs/common';
+import { DoctorService } from './doctor.service';
+
+@Controller('doctors')
+export class DoctorController {
+  constructor(private service: DoctorService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+
+  @Post()
+  create(@Body() data: any) {
+    return this.service.create(data);
+  }
+}

--- a/backend/src/doctor/doctor.module.ts
+++ b/backend/src/doctor/doctor.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Doctor } from '../entities/doctor.entity';
+import { DoctorService } from './doctor.service';
+import { DoctorController } from './doctor.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Doctor])],
+  controllers: [DoctorController],
+  providers: [DoctorService],
+  exports: [DoctorService],
+})
+export class DoctorModule {}

--- a/backend/src/doctor/doctor.service.ts
+++ b/backend/src/doctor/doctor.service.ts
@@ -1,0 +1,20 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Doctor } from '../entities/doctor.entity';
+
+@Injectable()
+export class DoctorService {
+  constructor(
+    @InjectRepository(Doctor) private repo: Repository<Doctor>,
+  ) {}
+
+  create(data: Partial<Doctor>) {
+    const doctor = this.repo.create(data);
+    return this.repo.save(doctor);
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+}

--- a/backend/src/entities/appointment.entity.ts
+++ b/backend/src/entities/appointment.entity.ts
@@ -1,0 +1,21 @@
+import { Entity, PrimaryGeneratedColumn, Column, ManyToOne } from 'typeorm';
+import { Doctor } from './doctor.entity';
+import { Patient } from './patient.entity';
+
+@Entity()
+export class Appointment {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @ManyToOne(() => Doctor)
+  doctor: Doctor;
+
+  @ManyToOne(() => Patient)
+  patient: Patient;
+
+  @Column()
+  time: string;
+
+  @Column({ default: 'booked' })
+  status: string;
+}

--- a/backend/src/entities/doctor.entity.ts
+++ b/backend/src/entities/doctor.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Doctor {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column()
+  specialization: string;
+
+  @Column({ nullable: true })
+  location: string;
+
+  @Column({ nullable: true })
+  gender: string;
+}

--- a/backend/src/entities/patient.entity.ts
+++ b/backend/src/entities/patient.entity.ts
@@ -1,0 +1,19 @@
+import { Entity, PrimaryGeneratedColumn, Column } from 'typeorm';
+
+@Entity()
+export class Patient {
+  @PrimaryGeneratedColumn()
+  id: number;
+
+  @Column()
+  name: string;
+
+  @Column({ nullable: true })
+  phone: string;
+
+  @Column({ default: 0 })
+  queueNumber: number;
+
+  @Column({ default: 'waiting' })
+  status: string;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -1,0 +1,10 @@
+import { NestFactory } from '@nestjs/core';
+import { AppModule } from './app.module';
+import './seed';
+
+async function bootstrap() {
+  const app = await NestFactory.create(AppModule);
+  await app.listen(3001);
+  console.log('Backend running on http://localhost:3001');
+}
+bootstrap();

--- a/backend/src/patient/patient.controller.ts
+++ b/backend/src/patient/patient.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { PatientService } from './patient.service';
+
+@Controller('patients')
+export class PatientController {
+  constructor(private service: PatientService) {}
+
+  @Get()
+  findAll() {
+    return this.service.findAll();
+  }
+}

--- a/backend/src/patient/patient.module.ts
+++ b/backend/src/patient/patient.module.ts
@@ -1,0 +1,13 @@
+import { Module } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Patient } from '../entities/patient.entity';
+import { PatientService } from './patient.service';
+import { PatientController } from './patient.controller';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Patient])],
+  providers: [PatientService],
+  controllers: [PatientController],
+  exports: [PatientService],
+})
+export class PatientModule {}

--- a/backend/src/patient/patient.service.ts
+++ b/backend/src/patient/patient.service.ts
@@ -1,0 +1,13 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Patient } from '../entities/patient.entity';
+
+@Injectable()
+export class PatientService {
+  constructor(@InjectRepository(Patient) private repo: Repository<Patient>) {}
+
+  findAll() {
+    return this.repo.find();
+  }
+}

--- a/backend/src/queue/queue.controller.ts
+++ b/backend/src/queue/queue.controller.ts
@@ -1,0 +1,25 @@
+import { Controller, Get, Post, Body, Patch, Param } from '@nestjs/common';
+import { QueueService } from './queue.service';
+
+@Controller('queue')
+export class QueueController {
+  constructor(private service: QueueService) {}
+
+  @Get()
+  getAll() {
+    return this.service.findAll();
+  }
+
+  @Post()
+  add(@Body('name') name: string) {
+    return this.service.addPatient(name);
+  }
+
+  @Patch(':id')
+  update(
+    @Param('id') id: string,
+    @Body('status') status: string,
+  ) {
+    return this.service.updateStatus(Number(id), status);
+  }
+}

--- a/backend/src/queue/queue.module.ts
+++ b/backend/src/queue/queue.module.ts
@@ -1,0 +1,12 @@
+import { Module } from '@nestjs/common';
+import { QueueService } from './queue.service';
+import { QueueController } from './queue.controller';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { Patient } from '../entities/patient.entity';
+
+@Module({
+  imports: [TypeOrmModule.forFeature([Patient])],
+  providers: [QueueService],
+  controllers: [QueueController],
+})
+export class QueueModule {}

--- a/backend/src/queue/queue.service.ts
+++ b/backend/src/queue/queue.service.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { Patient } from '../entities/patient.entity';
+
+@Injectable()
+export class QueueService {
+  constructor(@InjectRepository(Patient) private repo: Repository<Patient>) {}
+
+  async addPatient(name: string) {
+    const count = await this.repo.count();
+    const patient = this.repo.create({ name, queueNumber: count + 1, status: 'waiting' });
+    return this.repo.save(patient);
+  }
+
+  updateStatus(id: number, status: string) {
+    return this.repo.update({ id }, { status });
+  }
+
+  findAll() {
+    return this.repo.find();
+  }
+}

--- a/backend/src/seed.ts
+++ b/backend/src/seed.ts
@@ -1,0 +1,46 @@
+import 'reflect-metadata';
+import { DataSource } from 'typeorm';
+import { Doctor } from './entities/doctor.entity';
+import { Patient } from './entities/patient.entity';
+import { Appointment } from './entities/appointment.entity';
+
+const dataSource = new DataSource({
+  type: 'sqlite',
+  database: 'clinic.db',
+  entities: [Doctor, Patient, Appointment],
+  synchronize: true,
+});
+
+async function seed() {
+  await dataSource.initialize();
+
+  const doctorRepo = dataSource.getRepository(Doctor);
+  const patientRepo = dataSource.getRepository(Patient);
+  const apptRepo = dataSource.getRepository(Appointment);
+
+  if (await doctorRepo.count() === 0) {
+    const d1 = doctorRepo.create({ name: 'Dr. Smith', specialization: 'General' });
+    const d2 = doctorRepo.create({ name: 'Dr. Jones', specialization: 'Cardiology' });
+    await doctorRepo.save([d1, d2]);
+  }
+
+  if (await patientRepo.count() === 0) {
+    const p1 = patientRepo.create({ name: 'Alice', queueNumber: 1 });
+    const p2 = patientRepo.create({ name: 'Bob', queueNumber: 2 });
+    await patientRepo.save([p1, p2]);
+  }
+
+  if (await apptRepo.count() === 0) {
+    const [doctor] = await doctorRepo.find();
+    const [patient] = await patientRepo.find();
+    const appt = apptRepo.create({ doctor, patient, time: '10:00' });
+    await apptRepo.save(appt);
+  }
+
+  await dataSource.destroy();
+}
+
+seed().catch(err => {
+  console.error(err);
+  process.exit(1);
+});

--- a/frontend/pages/api/appointments.ts
+++ b/frontend/pages/api/appointments.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
+
+const backend = 'http://localhost:3001';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const response = await fetch(`${backend}/appointments`, {
+    method: req.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: req.method === 'POST' ? JSON.stringify(req.body) : undefined,
+  });
+  const data = await response.json();
+  res.status(200).json(data);
+}

--- a/frontend/pages/api/doctors.ts
+++ b/frontend/pages/api/doctors.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
+
+const backend = 'http://localhost:3001';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const response = await fetch(`${backend}/doctors`);
+  const data = await response.json();
+  res.status(200).json(data);
+}

--- a/frontend/pages/api/patients.ts
+++ b/frontend/pages/api/patients.ts
@@ -1,0 +1,10 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
+
+const backend = 'http://localhost:3001';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const response = await fetch(`${backend}/patients`);
+  const data = await response.json();
+  res.status(200).json(data);
+}

--- a/frontend/pages/api/queue/[id].ts
+++ b/frontend/pages/api/queue/[id].ts
@@ -1,0 +1,15 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
+
+const backend = 'http://localhost:3001';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const { id } = req.query;
+  const response = await fetch(`${backend}/queue/${id}`, {
+    method: req.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(req.body),
+  });
+  const data = await response.json();
+  res.status(200).json(data);
+}

--- a/frontend/pages/api/queue/index.ts
+++ b/frontend/pages/api/queue/index.ts
@@ -1,0 +1,14 @@
+import type { NextApiRequest, NextApiResponse } from 'next';
+import fetch from 'node-fetch';
+
+const backend = 'http://localhost:3001';
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  const response = await fetch(`${backend}/queue`, {
+    method: req.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: req.method === 'POST' ? JSON.stringify(req.body) : undefined,
+  });
+  const data = await response.json();
+  res.status(200).json(data);
+}

--- a/frontend/pages/appointments.tsx
+++ b/frontend/pages/appointments.tsx
@@ -1,0 +1,62 @@
+import { useEffect, useState } from 'react';
+
+export default function Appointments() {
+  const [appointments, setAppointments] = useState<any[]>([]);
+  const [patients, setPatients] = useState<any[]>([]);
+  const [doctors, setDoctors] = useState<any[]>([]);
+  const [doctorId, setDoctorId] = useState('');
+  const [patientId, setPatientId] = useState('');
+  const [time, setTime] = useState('');
+
+  useEffect(() => {
+    fetch('/api/appointments')
+      .then(res => res.json())
+      .then(setAppointments);
+    fetch('/api/patients')
+      .then(res => res.json())
+      .then(setPatients);
+    fetch('/api/doctors')
+      .then(res => res.json())
+      .then(setDoctors);
+  }, []);
+
+  const book = async () => {
+    await fetch('/api/appointments', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ patientId: Number(patientId), doctorId: Number(doctorId), time }),
+    });
+    setTime('');
+    setDoctorId('');
+    setPatientId('');
+    const res = await fetch('/api/appointments');
+    setAppointments(await res.json());
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Appointments</h1>
+      <div className="mt-2 space-x-2">
+        <select className="border" value={patientId} onChange={e => setPatientId(e.target.value)}>
+          <option value="">Select patient</option>
+          {patients.map((p: any) => (
+            <option key={p.id} value={p.id}>{p.name}</option>
+          ))}
+        </select>
+        <select className="border" value={doctorId} onChange={e => setDoctorId(e.target.value)}>
+          <option value="">Select doctor</option>
+          {doctors.map((d: any) => (
+            <option key={d.id} value={d.id}>{d.name}</option>
+          ))}
+        </select>
+        <input className="border p-1" placeholder="Time" value={time} onChange={e => setTime(e.target.value)} />
+        <button onClick={book} className="px-2 py-1 bg-blue-500 text-white">Book</button>
+      </div>
+      <ul className="mt-4 list-disc ml-4">
+        {appointments.map(a => (
+          <li key={a.id}>{a.patient?.name} with {a.doctor?.name} at {a.time}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/frontend/pages/index.tsx
+++ b/frontend/pages/index.tsx
@@ -1,0 +1,11 @@
+export default function Home() {
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Front Desk System</h1>
+      <ul className="list-disc ml-4 mt-4">
+        <li><a href="/queue" className="text-blue-500">Queue Management</a></li>
+        <li><a href="/appointments" className="text-blue-500">Appointments</a></li>
+      </ul>
+    </div>
+  );
+}

--- a/frontend/pages/queue.tsx
+++ b/frontend/pages/queue.tsx
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+
+export default function Queue() {
+  const [patients, setPatients] = useState<any[]>([]);
+  const [name, setName] = useState('');
+
+  useEffect(() => {
+    fetch('/api/queue')
+      .then(res => res.json())
+      .then(setPatients);
+  }, []);
+
+  const refresh = async () => {
+    const res = await fetch('/api/queue');
+    setPatients(await res.json());
+  };
+
+  const add = async () => {
+    await fetch('/api/queue', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    });
+    setName('');
+    refresh();
+  };
+
+  const updateStatus = async (id: number, status: string) => {
+    await fetch(`/api/queue/${id}`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status }),
+    });
+    refresh();
+  };
+
+  return (
+    <div className="p-4">
+      <h1 className="text-xl font-bold">Queue</h1>
+      <div className="mt-2">
+        <input
+          value={name}
+          onChange={e => setName(e.target.value)}
+          className="border p-1"
+          placeholder="Patient name"
+        />
+        <button onClick={add} className="ml-2 px-2 py-1 bg-blue-500 text-white">Add</button>
+      </div>
+      <ul className="mt-4 list-disc ml-4">
+        {patients.map(p => (
+          <li key={p.id} className="mb-2">
+            <span className="mr-2 font-semibold">#{p.queueNumber}</span>
+            {p.name} - {p.status}
+            <select
+              className="ml-2 border"
+              value={p.status}
+              onChange={e => updateStatus(p.id, e.target.value)}
+            >
+              <option value="waiting">Waiting</option>
+              <option value="with-doctor">With Doctor</option>
+              <option value="completed">Completed</option>
+            </select>
+          </li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "front-desk-allo-health-hg",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "npx ts-node backend/src/main.ts",
+    "seed": "npx ts-node backend/src/seed.ts",
+    "dev": "cd frontend && npm run dev"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es2017",
+    "lib": ["es2017"],
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  },
+  "include": ["backend/src/**/*"],
+  "exclude": ["node_modules"]
+}


### PR DESCRIPTION
## Summary
- expand patient entity with queue info
- add queue status updates and frontend controls
- implement seed script and patient module
- enhance appointment booking UI
- provide seeding and deployment notes in README

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npx ts-node backend/src/main.ts` *(fails: npm ERR! 403 Forbidden - GET https://registry.npmjs.org/ts-node)*

------
https://chatgpt.com/codex/tasks/task_e_6888f34caf68832bb0bc29ac38577ce7